### PR TITLE
Fix PageField references

### DIFF
--- a/djangocms_4_migration/management/commands/migrate_alias_plugins.py
+++ b/djangocms_4_migration/management/commands/migrate_alias_plugins.py
@@ -252,7 +252,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         with transaction.atomic():
             # Alias source plugin list
-            cms3_alias_ref_ids = AliasPluginModel.objects.values('plugin_id').order_by('plugin_id').distinct('plugin_id')
+            cms3_alias_ref_ids = set(AliasPluginModel.objects.values('plugin_id').order_by('plugin_id').distinct())
             plugin_id_list = [cms3_plugin['plugin_id'] for cms3_plugin in cms3_alias_ref_ids if cms3_plugin['plugin_id']]
             alias_source_total = len(plugin_id_list)
             # Alias references list count


### PR DESCRIPTION
Extends @stefanw's work to update references to Page's within the cms PageField.
Also adds a small guard against creating duplicate categories just in case you want to run the migration command twice!

